### PR TITLE
Upgrade Leaflet.Deflate to >= 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -413,9 +413,9 @@
       "dev": true
     },
     "Leaflet.Deflate": {
-      "version": "1.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/Leaflet.Deflate/-/Leaflet.Deflate-1.0.0-alpha.5.tgz",
-      "integrity": "sha512-joYUSfTT4QUhCqsLxIE69uHFNRWTUUAN7Qp1anTQkVfGMkHvnlIdsvzAol3VtGQQzLe7TFLRUqiRqctbrdCSOw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/Leaflet.Deflate/-/Leaflet.Deflate-1.1.0.tgz",
+      "integrity": "sha512-uWUhiTlj2dL8b0LL7n/Eg3QJfuKqKAwAEThhTg9XgwBP/IwdPZ2sE+Cg2dZBQ6q8yXzgZFDXV9JIjvQ7kXnG4w=="
     },
     "abab": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"webpack-dev-server": "^3.1.14"
 	},
 	"dependencies": {
-		"Leaflet.Deflate": "^1.0.0-alpha.5"
+		"Leaflet.Deflate": "^1.1.0"
 	},
 	"jest": {
 		"collectCoverage": true,


### PR DESCRIPTION
Hey @mhasbie,

I recently released Leaflet.Deflate 1.0, which contains improvements for better integration with Leaflet and other Leaflet plugins. I recommend you use the new release since it's more stable than the alpha from last November. 